### PR TITLE
Fix indentation in the Cakefile

### DIFF
--- a/htdocs/coffee/Cakefile
+++ b/htdocs/coffee/Cakefile
@@ -40,7 +40,7 @@ task 'build', 'Build single application file from source files', ->
 
 task 'docs', 'Build docs with docco (required)', ->
     appContents = new Array remaining = appFiles.length
-      for file, index in appFiles then do (file, index) ->
+    for file, index in appFiles then do (file, index) ->
         fs.readFile "src/#{file}.coffee", 'utf8', (err, fileContents) ->
           throw err if err
           appContents[index] = fileContents


### PR DESCRIPTION
Somehow the indentation has gotten screwed up, and this has interfered with the ability to build the coffee files. I've verified that this fixes the problem, with coffee 1.7.1. Alas, I have not verified that it does not create _new_ problems on older versions. Such is our ever-changing software development landscape.
