### PR TITLE
Stop accessing missing properties of Document

### DIFF
--- a/htdocs/coffee/src/run.coffee
+++ b/htdocs/coffee/src/run.coffee
@@ -100,7 +100,7 @@ Document::run = ->
     
     true
 
-if Document::body and Document::run
+if document.hasOwnProperty('body') and document.hasOwnProperty('run')
     document.run()
 else
     JQ(document).ready(Document::run)


### PR DESCRIPTION
This fixes the script on IE. Apparently, according to the WebIDL standard, you should not be able to access these properties, even to check if they exist, and so IE keeps you from doing it. It's arguable if the standard means anything if IE is the only browser to follow it, but that's the web for you.

A simple workaround is to ask hasOwnProperty(); alas, this defeats some of the prettiness of the coffeescript. Its only advantage is that it is functional.
